### PR TITLE
Removed premature callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,11 @@ function process(file, data, callback) {
       if (path.resolve(val) == path.resolve(file) && pack['browserify-window-context'].indexOf(key) != -1) {
         res = '(function () {' + data + '}).apply(window);';
         callback(res);
+      } else {
+        callback(data);
       }
     });
   });
-  callback(data);
 }
 function transform(file) {
   var data = '', stream = through(write, end);

--- a/index.js
+++ b/index.js
@@ -4,17 +4,24 @@ var through = require('through');
 var path = require('path');
 function process(file, data, callback) {
   mothership(file, function (pack) { return !! pack['browser'] && !! pack['browserify-window-context'] }, function (err, res) {
-    pack = res.pack
+    pack = res.pack;
     browser = pack['browser'];
-    Object.keys(browser).forEach(function(key) {
-      var val = browser[key];
-      if (path.resolve(val) == path.resolve(file) && pack['browserify-window-context'].indexOf(key) != -1) {
-        res = '(function () {' + data + '}).apply(window);';
-        callback(res);
-      } else {
-        callback(data);
+    var filePath = path.resolve(file);
+    var mustAddWindowContext = Object.keys(browser).reduce(function(result, key) {
+      var shimPath = path.resolve(browser[key]);
+
+      if (shimPath !== filePath) {
+        return result;
       }
-    });
+
+      return result || pack['browserify-window-context'].indexOf(key) !== -1;
+    }, false);
+
+    if (mustAddWindowContext) {
+      data = '(function () {' + data + '}).apply(window);';
+    }
+    
+    callback(data);
   });
 }
 function transform(file) {


### PR DESCRIPTION
Hey,

I couldn't get this transformation to work, I never got the window context applied so I did some digging.

The callback is being called immediately with the file's default contents, for every file.
When the callback is called: 1. the contents are written to the stream, and 2. null is being written to the stream. Effectively signalling that we're done writing to it.

The callback will be called again for files that need the transformation, but since the stream has already been marked as "ended" this will have no effect.

I changed the code so that the callback is only called once.
- Either with the original contents of the file (if no transformation is needed)
- Or with the transformed contents of the transformation is needed.

I can see on NPM this plugin is actually used by people (200 DLs/week) but I don't get how it has ever been able to work?